### PR TITLE
removed ng-app

### DIFF
--- a/Skyrim.CompositeUI/Index.html
+++ b/Skyrim.CompositeUI/Index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" ng-app="skyrim">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <title>Skyrim project</title>
 <!--    <script src="Scripts/angular.js"></script>


### PR DESCRIPTION
Note: You should not use the ng-app directive when manually bootstrapping your app.